### PR TITLE
#116 - improve mobile view of careers page

### DIFF
--- a/src/components/lead-section.svelte
+++ b/src/components/lead-section.svelte
@@ -1,5 +1,5 @@
 <Section classes="{ classes }">
-    <div class="md:flex-1 { headerClasses }">
+    <div class="md:flex-1 w-full { headerClasses }">
         <div class="text-4xl font-bold">
             <slot name="header"/>
         </div>

--- a/src/components/ribbon.svelte
+++ b/src/components/ribbon.svelte
@@ -1,5 +1,5 @@
-<div class="w-full bg-gradient-to-tr from-brand to-blue-400 text-white mt-12 xl:mt-24 mb-12 p-4 sm:p-12 shadow-lg">
-    <div class="container">
+<div class="w-full bg-gradient-to-tr from-brand to-blue-400 text-white mt-12 xl:mt-24 mb-12 p-12 shadow-lg">
+    <div class="container mx-auto">
         <slot/>
     </div>
 </div>

--- a/src/components/section.svelte
+++ b/src/components/section.svelte
@@ -1,4 +1,4 @@
-<div class="container px-2 sm:px-6 mx-auto text-center lg:text-left flex justify-center items-center flex-col lg:flex-row py-4 lg:py-0 { classes }">
+<div class="container px-6 mx-auto text-center lg:text-left flex justify-center items-center flex-col lg:flex-row py-4 lg:py-0 { classes }">
     <slot/>
 </div>
 

--- a/src/pages/career/index.svelte
+++ b/src/pages/career/index.svelte
@@ -1,6 +1,6 @@
 <Meta title={ $_('title.career') }/>
 
-<LeadSection class="w-full">
+<LeadSection>
     <div slot="header">
         { $_('pages.career.header') }
     </div>
@@ -10,9 +10,9 @@
         {:else}
             { $_('pages.career.lead') }
 
-            <div class=" m-2 sm:m-12 flex flex-row gap-2">
+            <div class="mt-12 sm:m-12 flex flex-row gap-2">
                 {#each jobs as job}
-                    <a href="{ $url(job.url) }" class="flex justify-center items-center w-full py-2 px-4 rounded-md text-white bg-brand hover:bg-blue-500 text-white">
+                    <a href="{ $url(job.url) }" class="flex justify-center text-center items-center w-full py-2 px-2 rounded-md text-white bg-brand hover:bg-blue-500">
                         { $_(job.name) }
                     </a>
                 {/each}


### PR DESCRIPTION
This should close #116.

Before changes:
![image](https://user-images.githubusercontent.com/56546832/136762754-b7b4d416-8c11-4f77-a7ad-e5ddf25bf5a7.png)

![image](https://user-images.githubusercontent.com/56546832/136762794-98946a72-d936-40e7-8636-343fc9a417a6.png)



After changes:

![image](https://user-images.githubusercontent.com/56546832/136762649-cc935bf0-75d6-45bf-820c-d087a0f9031a.png)

![image](https://user-images.githubusercontent.com/56546832/136762696-eb8994e8-17e2-4113-ad9c-05a0473b9cfa.png)
