### PR TITLE
#147 - master to main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,11 +3,12 @@ name: "Checking app: testing and linting"
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   check:
     runs-on: ubuntu-20.04
+    name: "Checking app: testing and linting"
     container:
       image: cypress/browsers:node14.17.0-chrome88-ff89
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,11 +3,12 @@ name: "Deploying website to GitHub Pages"
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:
     runs-on: ubuntu-20.04
+    name: "Deploying website to GitHub Pages"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -2,6 +2,8 @@ name: "Check the PR title"
 
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - edited


### PR DESCRIPTION
To unify all our repositories, I renamed `master` branch to `main`. It should close #147.

Btw, to all other developers:
>  The default branch has been renamed! `master` is now named `main`
> If you have a local clone, you can update it by running the following commands.
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```