### PR TITLE
#159 - change illustrations padding for smaller resolutions

### DIFF
--- a/src/components/lead-section.svelte
+++ b/src/components/lead-section.svelte
@@ -1,6 +1,6 @@
 <Section classes="{ classes }">
     <div class="md:flex-1 w-full { headerClasses }">
-        <div class="text-4xl font-bold">
+        <div class="text-3xl sm:text-4xl font-bold">
             <slot name="header"/>
         </div>
         <div class="mt-8 text-lg text-gray-500">

--- a/src/layout/footer.svelte
+++ b/src/layout/footer.svelte
@@ -1,6 +1,6 @@
 <footer class="mt-12 z-20">
-    <div class="container mx-auto py-8 px-4 sm:px-6 md:flex md:items-center md:justify-between lg:px-8">
-        <div class="flex justify-center space-x-6 md:order-2 text-lg">
+    <div class="container mx-auto py-8 px-4 sm:px-6 lg:flex lg:items-center lg:justify-between lg:px-8">
+        <div class="flex justify-center space-x-6 lg:order-2 text-lg">
             {#each socials as social}
                 <a href="{ social.url }" target="_blank" class="text-gray-500 hover:text-gray-900" title="{ social.name }">
                     <span class="sr-only">{ social.name }</span>
@@ -8,10 +8,10 @@
                 </a>
             {/each}
         </div>
-        <div class="mt-8 md:mt-0 md:order-1">
+        <div class="mt-8 lg:mt-0 lg:order-1">
             <div class="text-center text-base text-gray-700">
                 <span>&copy; { year } Blumilk</span>
-                <div class="block md:inline">
+                <div class="block lg:inline">
                     <a href="{ $url('./privacy') }" class="hover:text-gray-900 ml-4">{ $_('footer.privacy') }</a>
                     <a href="{ $url('./company') }" class="hover:text-gray-900 ml-4">{ $_('footer.company') }</a>
                     <a href="https://github.com/blumilksoftware/website" target="_blank" class="hover:text-gray-900 ml-4">{ $_('footer.source') }</a>

--- a/src/layout/footer.svelte
+++ b/src/layout/footer.svelte
@@ -11,7 +11,7 @@
         <div class="mt-8 lg:mt-0 lg:order-1">
             <div class="text-center text-base text-gray-700">
                 <span>&copy; { year } Blumilk</span>
-                <div class="block lg:inline">
+                <div class="text-center block lg:inline">
                     <a href="{ $url('./privacy') }" class="hover:text-gray-900 ml-4">{ $_('footer.privacy') }</a>
                     <a href="{ $url('./company') }" class="hover:text-gray-900 ml-4">{ $_('footer.company') }</a>
                     <a href="https://github.com/blumilksoftware/website" target="_blank" class="hover:text-gray-900 ml-4">{ $_('footer.source') }</a>
@@ -32,6 +32,7 @@
 <style>
     .clutch.icon {
         margin-top: 5px;
+        margin-left: 24px;
         width: 18px;
         height: 18px;
         background-size: cover;

--- a/src/pages/career/index.svelte
+++ b/src/pages/career/index.svelte
@@ -9,7 +9,7 @@
         {:else}
             { $_('pages.career.lead') }
 
-            <div class="mt-12 sm:m-12 flex flex-row gap-2 relative z-10">
+            <div class="mt-12 sm:m-12 flex flex-col sm:flex-row gap-2 relative z-10">
                 {#each jobs as job}
                     <a href="{ $url(job.url) }" class="flex justify-center text-center items-center w-full py-2 px-2 rounded-md text-white bg-brand hover:bg-blue-500">
                         { $_(job.name) }
@@ -19,7 +19,7 @@
         {/if}
     </div>
     <div slot="content">
-        <img class="p-24 lg:px-24 relative z-10 pointer-events-none" src="/images/illustrations/cv.svg" alt="{ $_('pages.career.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/cv.svg" alt="{ $_('pages.career.header') }"
                 title="{ $_('pages.career.header') }">
     </div>
 </LeadSection>

--- a/src/pages/company.svelte
+++ b/src/pages/company.svelte
@@ -26,11 +26,11 @@
     <div slot="content" class="lg:text-right lg:mr-24 font-bold">
         <div class="my-8">
             <div class="text-3xl opacity-75">NIP</div>
-            <div class="text-5xl" data-cy="nip">{ contact.nip }</div>
+            <div class="text-4xl" data-cy="nip">{ contact.nip }</div>
         </div>
         <div class="my-8">
             <div class="text-3xl opacity-75">VAT</div>
-            <div class="text-5xl">{ contact.vat }</div>
+            <div class="text-4xl">{ contact.vat }</div>
         </div>
         <div class="my-8">
             <div class="text-xl opacity-75">REGON</div>

--- a/src/pages/contact.svelte
+++ b/src/pages/contact.svelte
@@ -33,7 +33,7 @@
         </form>
     </div>
     <div slot="content">
-        <img class="px-24 lg:p-24 relative z-10 pointer-events-none" src="/images/illustrations/contact.svg"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/contact.svg"
              alt="{ $_('pages.contact.header') }" title="{ $_('pages.contact.header') }">
     </div>
 </Section>

--- a/src/pages/index.svelte
+++ b/src/pages/index.svelte
@@ -5,11 +5,11 @@
         <span class="text-brand">{ $_('pages.home.hero.focus') }</span>
         { $_('pages.home.hero.suffix') }
     </div>
-    <div slot="description" class="mt-16 text-xl">
+    <div slot="description" class="text-xl">
         { $_('pages.home.hero.about') }
     </div>
     <div slot="content">
-        <img class="p-24 relative z-10 pointer-events-none" src="/images/illustrations/software.svg"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/software.svg"
              alt="{ $_('pages.home.hero.prefix') } { $_('pages.home.hero.focus') } { $_('pages.home.hero.suffix') }"
              title="{ $_('pages.home.hero.prefix') } { $_('pages.home.hero.focus') } { $_('pages.home.hero.suffix') }">
     </div>
@@ -20,7 +20,7 @@
         { $_('pages.home.academic.header') }
     </div>
     <div slot="description">
-        <div class="mt-16 text-xl text-gray-500">
+        <div class="text-xl text-gray-500">
             {#each $_('pages.home.academic.content') as item}
                 <p class="pb-4">
                     { item }
@@ -29,7 +29,7 @@
         </div>
     </div>
     <div slot="content">
-        <img class="px-24 lg:p-24 relative z-10 pointer-events-none" src="/images/illustrations/uni.svg" alt="{ $_('pages.home.academic.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/uni.svg" alt="{ $_('pages.home.academic.header') }"
              title="{ $_('pages.home.academic.header') }">
     </div>
 </Section>
@@ -39,7 +39,7 @@
         { $_('pages.home.tools.header') }
     </div>
     <div slot="description">
-        <div class="mt-16 text-xl text-gray-500">
+        <div class="text-xl text-gray-500">
             {#each $_('pages.home.tools.content') as item}
                 <p class="pb-4">
                     { item }
@@ -48,7 +48,7 @@
         </div>
     </div>
     <div slot="content">
-        <img class="px-24 lg:p-24 relative z-10 pointer-events-none" src="/images/illustrations/tools.svg" alt="{ $_('pages.home.tools.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/tools.svg" alt="{ $_('pages.home.tools.header') }"
              title="{ $_('pages.home.tools.header') }">
     </div>
 </Section>
@@ -58,7 +58,7 @@
         { $_('pages.home.projects.header') }
     </div>
     <div slot="description">
-        <div class="mt-16 text-xl text-gray-500">
+        <div class="text-xl text-gray-500">
             {#each $_('pages.home.projects.content') as item}
                 <p class="pb-4">
                     { item }
@@ -67,7 +67,7 @@
         </div>
     </div>
     <div slot="content">
-        <img class="px-24 lg:p-24 relative z-10 pointer-events-none" src="/images/illustrations/projects.svg" alt="{ $_('pages.home.projects.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/projects.svg" alt="{ $_('pages.home.projects.header') }"
              title="{ $_('pages.home.projects.header') }">
     </div>
 </Section>

--- a/src/pages/index.svelte
+++ b/src/pages/index.svelte
@@ -1,6 +1,6 @@
 <Meta title={ $_('title.blumilk-software-development') } description={ $_('description.blumilk-software-development') }/>
 <Section>
-    <div slot="header" class="text-4xl md:text-5xl lg:text-6xl">
+    <div slot="header" class="text-3xl sm:text-4xl md:text-5xl lg:text-6xl">
         { $_('pages.home.hero.prefix') }
         <span class="text-brand">{ $_('pages.home.hero.focus') }</span>
         { $_('pages.home.hero.suffix') }

--- a/src/pages/partnerships.svelte
+++ b/src/pages/partnerships.svelte
@@ -9,7 +9,7 @@
             { $_(partner.lead) }
         </div>
         <div slot="content">
-            <img class="p-12 relative z-10 pointer-events-none w-4/5 sm:w-3/5 md:w-3/4 xl:w-1/2 m-auto" src="{ partner.logo }" alt="{ $_(partner.header) }" title="{ $_(partner.header) }">
+            <img class="p-4 sm:p-12 relative z-10 pointer-events-none w-4/5 sm:w-3/5 md:w-3/4 m-auto" src="{ partner.logo }" alt="{ $_(partner.header) }" title="{ $_(partner.header) }">
         </div>
     </Section>
 {/each}

--- a/src/pages/privacy.svelte
+++ b/src/pages/privacy.svelte
@@ -12,7 +12,7 @@
         {/each}
     </div>
     <div slot="content">
-        <img class="px-24 lg:p-24 relative z-10 pointer-events-none" src="/images/illustrations/privacy.svg" alt="{ $_('pages.privacy.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/privacy.svg" alt="{ $_('pages.privacy.header') }"
              title="{ $_('pages.privacy.header') }">
     </div>
 </LeadSection>

--- a/src/pages/services.svelte
+++ b/src/pages/services.svelte
@@ -7,7 +7,7 @@
         { $_('pages.services.r&d.lead') }
     </div>
     <div slot="content">
-        <img class="p-24 relative z-10 pointer-events-none" src="/images/illustrations/rnd.svg" alt="{ $_('pages.services.r&d.header') }" data-cy="rnd-image"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/rnd.svg" alt="{ $_('pages.services.r&d.header') }" data-cy="rnd-image"
                 title="{ $_('pages.services.r&d.header') }">
     </div>
 </Section>
@@ -20,7 +20,7 @@
         { $_('pages.services.web.lead') }
     </div>
     <div slot="content">
-        <img class="p-24 relative z-10 pointer-events-none" src="/images/illustrations/web.svg" alt="{ $_('pages.services.web.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/web.svg" alt="{ $_('pages.services.web.header') }"
                 title="{ $_('pages.services.web.header') }">
     </div>
 </Section>
@@ -33,7 +33,7 @@
         { $_('pages.services.business.lead') }
     </div>
     <div slot="content">
-        <img class="p-24 relative z-10 pointer-events-none" src="/images/illustrations/data.svg" alt="{ $_('pages.services.business.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/data.svg" alt="{ $_('pages.services.business.header') }"
                 title="{ $_('pages.services.business.header') }">
     </div>
 </Section>

--- a/src/sections/about/photos.svelte
+++ b/src/sections/about/photos.svelte
@@ -1,61 +1,61 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-4 gap-4 mt-16 mx-auto">
     <div class="row-span-2">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/meetup3.jpg" alt="{ $_('pages.about.photos.meetup3') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/meetup3.jpg" alt="{ $_('pages.about.photos.meetup3') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.meetup3') }</div>
         </div>
     </div>
     <div class="">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/birthday.jpg" alt="{ $_('pages.about.photos.birthday') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/birthday.jpg" alt="{ $_('pages.about.photos.birthday') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.birthday') }</div>
         </div>
     </div>
     <div class="">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/lasertag.jpg" alt="{ $_('pages.about.photos.lasertag') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/lasertag.jpg" alt="{ $_('pages.about.photos.lasertag') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.lasertag') }</div>
         </div>
     </div>
     <div class="">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/helsinki.jpg" alt="{ $_('pages.about.photos.helsinki') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/helsinki.jpg" alt="{ $_('pages.about.photos.helsinki') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.helsinki') }</div>
         </div>
     </div>
     <div class="">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/meetup.jpg" alt="{ $_('pages.about.photos.meetup') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/meetup.jpg" alt="{ $_('pages.about.photos.meetup') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.meetup') }</div>
         </div>
     </div>
     <div class="row-span-2 2xl:row-span-3">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/quantum.jpg" alt="{ $_('pages.about.photos.quantum') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/quantum.jpg" alt="{ $_('pages.about.photos.quantum') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.quantum') }</div>
         </div>
     </div>
     <div class="">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/energylandia.jpg" alt="{ $_('pages.about.photos.energylandia') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/energylandia.jpg" alt="{ $_('pages.about.photos.energylandia') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.energylandia') }</div>
         </div>
     </div>
     <div class="">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/meetup2.jpg" alt="{ $_('pages.about.photos.meetup2') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/meetup2.jpg" alt="{ $_('pages.about.photos.meetup2') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.meetup2') }</div>
         </div>
     </div>
     <div class="">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/rzeka.jpg" alt="{ $_('pages.about.photos.rzeka') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/rzeka.jpg" alt="{ $_('pages.about.photos.rzeka') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.rzeka') }</div>
         </div>
     </div>
     <div class="">
         <div class="bg-white rounded-xl text-center shadow-lg w-max">
-            <img src="/images/photos/plane.jpg" alt="{ $_('pages.about.photos.plane') }" class="w-96 p-2 relative z-10">
+            <img src="/images/photos/plane.jpg" alt="{ $_('pages.about.photos.plane') }" class="w-80 sm:w-96 sm:relative sm:z-10 p-2">
             <div class="pb-2 text-xs text-gray-600">{ $_('pages.about.photos.plane') }</div>
         </div>
     </div>

--- a/src/sections/about/references.svelte
+++ b/src/sections/about/references.svelte
@@ -1,7 +1,7 @@
 <Section classes="md:my-12 items-start" disableColumns="true">
     <div slot="header">{ $_('pages.about.references.header') }</div>
     <div slot="description" class="text-center lg:text-left lg:w-2/3">
-        <p class="pr-4">
+        <p>
             { $_('pages.about.references.lead') }
             <a class="font-bold text-brand" href="https://clutch.co/profile/blumilk-0" target="_blank">Clutch</a>.
         </p>

--- a/src/sections/about/references.svelte
+++ b/src/sections/about/references.svelte
@@ -1,19 +1,17 @@
-<Section classes="my-24 items-start" disableColumns="true">
+<Section classes="md:my-12 items-start" disableColumns="true">
     <div slot="header">{ $_('pages.about.references.header') }</div>
-    <div slot="description" class="w-2/3">
+    <div slot="description" class="text-center lg:text-left lg:w-2/3">
         <p class="pr-4">
             { $_('pages.about.references.lead') }
-            <a class="font-bold" href="https://clutch.co/profile/blumilk-0" target="_blank">Clutch</a>.
+            <a class="font-bold text-brand" href="https://clutch.co/profile/blumilk-0" target="_blank">Clutch</a>.
         </p>
-        <div class="my-12 grid grid-cols-2 md:grid-cols-5 gap-4 md:mr-16 md:mb-0 items-center">
-        </div>
     </div>
 </Section>
 
-<div class="container flex items-center justify-content w-full mx-auto text-gray-400 px-16 text-sm text-center md:text-left" data-cy="references-images">
+<div class="container px-6 mx-auto flex justify-center items-center flex-col lg:flex-row py-4 md:mb-12 xl:mb-0" data-cy="references-images">
     {#each clients as client}
         <div class="flex-1">
-            <img src="{ client.logo }" alt="{ client.name }" title="{ client.name }" class="mx-auto relative z-10 w-32">
+            <img src="{ client.logo }" alt="{ client.name }" title="{ client.name }" class="mx-auto relative z-10 w-48">
         </div>
     {/each}
 </div>

--- a/src/sections/gdpr.svelte
+++ b/src/sections/gdpr.svelte
@@ -1,4 +1,4 @@
-<div class="container mx-auto text-gray-400 px-16 text-sm text-center md:text-left">
+<div class="container mx-auto text-gray-400 px-8 sm:px-16 text-sm text-center md:text-left">
     { $_('pages.career.gdpr') }
 </div>
 


### PR DESCRIPTION
This should close #159.

- changed illustrations padding for smaller resolutions

Before:
![image](https://user-images.githubusercontent.com/56546832/170213370-f8b6d95f-a6e5-456f-bec5-496ec2b508ac.png)

After:
![image](https://user-images.githubusercontent.com/56546832/170216374-e955081a-e782-4f6b-aff8-7fb8118ab6d9.png)

- redesigned references section for mobiles

Before:
![image](https://user-images.githubusercontent.com/56546832/170219206-849b8689-5db5-4027-908a-71617f492c71.png)

After:
![image](https://user-images.githubusercontent.com/56546832/170218983-6d4b2a85-0c02-4304-82d5-b95e029d043e.png)

- reduced headers text-size on home page (only for mobiles), because it looks bad on smaller resolutions

Before:
![image](https://user-images.githubusercontent.com/56546832/170215616-b265bdc2-f9c4-4d69-838e-7c1e7b55c492.png)

After:
![image](https://user-images.githubusercontent.com/56546832/170216281-d1dbb5e3-c4c7-40d1-8b83-52e750e40273.png)

- fixed footer, because on medium resolutions looks unattractive

Before:

![image](https://user-images.githubusercontent.com/56546832/170218160-430bff02-0be6-435b-a1df-13edd7ba8f34.png)

After:
![image](https://user-images.githubusercontent.com/56546832/170218414-4af8fe2f-acc4-4415-b52e-ef50259f6c06.png)

 