### PR TITLE
#159 - fix image padding for bigger resolutions

### DIFF
--- a/src/pages/career/developer.svelte
+++ b/src/pages/career/developer.svelte
@@ -9,7 +9,7 @@
         <p class="py-2">{ $_('pages.career.jobs.developer.description.1') }</p>
     </div>
     <div slot="content">
-        <img class="px-12 lg:px-24 relative z-10 pointer-events-none" src="/images/illustrations/developer.svg" alt="{ $_('pages.career.header') }" title="{ $_('pages.career.header') }">
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/developer.svg" alt="{ $_('pages.career.header') }" title="{ $_('pages.career.header') }">
     </div>
 </LeadSection>
 

--- a/src/pages/career/index.svelte
+++ b/src/pages/career/index.svelte
@@ -19,7 +19,7 @@
         {/if}
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/cv.svg" alt="{ $_('pages.career.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/cv.svg" alt="{ $_('pages.career.header') }"
                 title="{ $_('pages.career.header') }">
     </div>
 </LeadSection>

--- a/src/pages/career/intern.svelte
+++ b/src/pages/career/intern.svelte
@@ -11,7 +11,7 @@
         <p class="py-2">{ $_('pages.career.jobs.intern.description.3') }</p>
     </div>
     <div slot="content">
-        <img class="px-12 lg:px-24 relative z-10 pointer-events-none" src="/images/illustrations/intern.svg" alt="{ $_('pages.career.header') }" title="{ $_('pages.career.header') }">
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/intern.svg" alt="{ $_('pages.career.header') }" title="{ $_('pages.career.header') }">
     </div>
 </LeadSection>
 

--- a/src/pages/contact.svelte
+++ b/src/pages/contact.svelte
@@ -33,7 +33,7 @@
         </form>
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/contact.svg"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/contact.svg"
              alt="{ $_('pages.contact.header') }" title="{ $_('pages.contact.header') }">
     </div>
 </Section>

--- a/src/pages/index.svelte
+++ b/src/pages/index.svelte
@@ -9,7 +9,7 @@
         { $_('pages.home.hero.about') }
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/software.svg"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/software.svg"
              alt="{ $_('pages.home.hero.prefix') } { $_('pages.home.hero.focus') } { $_('pages.home.hero.suffix') }"
              title="{ $_('pages.home.hero.prefix') } { $_('pages.home.hero.focus') } { $_('pages.home.hero.suffix') }">
     </div>
@@ -29,7 +29,7 @@
         </div>
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/uni.svg" alt="{ $_('pages.home.academic.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/uni.svg" alt="{ $_('pages.home.academic.header') }"
              title="{ $_('pages.home.academic.header') }">
     </div>
 </Section>
@@ -48,7 +48,7 @@
         </div>
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/tools.svg" alt="{ $_('pages.home.tools.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/tools.svg" alt="{ $_('pages.home.tools.header') }"
              title="{ $_('pages.home.tools.header') }">
     </div>
 </Section>
@@ -67,7 +67,7 @@
         </div>
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/projects.svg" alt="{ $_('pages.home.projects.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/projects.svg" alt="{ $_('pages.home.projects.header') }"
              title="{ $_('pages.home.projects.header') }">
     </div>
 </Section>

--- a/src/pages/privacy.svelte
+++ b/src/pages/privacy.svelte
@@ -12,7 +12,7 @@
         {/each}
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/privacy.svg" alt="{ $_('pages.privacy.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/privacy.svg" alt="{ $_('pages.privacy.header') }"
              title="{ $_('pages.privacy.header') }">
     </div>
 </LeadSection>

--- a/src/pages/services.svelte
+++ b/src/pages/services.svelte
@@ -7,7 +7,7 @@
         { $_('pages.services.r&d.lead') }
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/rnd.svg" alt="{ $_('pages.services.r&d.header') }" data-cy="rnd-image"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/rnd.svg" alt="{ $_('pages.services.r&d.header') }" data-cy="rnd-image"
                 title="{ $_('pages.services.r&d.header') }">
     </div>
 </Section>
@@ -20,7 +20,7 @@
         { $_('pages.services.web.lead') }
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/web.svg" alt="{ $_('pages.services.web.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/web.svg" alt="{ $_('pages.services.web.header') }"
                 title="{ $_('pages.services.web.header') }">
     </div>
 </Section>
@@ -33,7 +33,7 @@
         { $_('pages.services.business.lead') }
     </div>
     <div slot="content">
-        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-24 lg:p-10 relative z-10 pointer-events-none" src="/images/illustrations/data.svg" alt="{ $_('pages.services.business.header') }"
+        <img class="px-4 py-8 sm:px-16 sm:py-8 md:px-12 xl:p-24 relative z-10 pointer-events-none" src="/images/illustrations/data.svg" alt="{ $_('pages.services.business.header') }"
                 title="{ $_('pages.services.business.header') }">
     </div>
 </Section>


### PR DESCRIPTION
So, my previous pr #161 broke paddings for bigger resolutions and this pr fixes this.

Before (broken):
![image](https://user-images.githubusercontent.com/56546832/170964720-794a77dd-4782-4adb-8cad-d1aa889e27de.png)


After (fixed): 
![image](https://user-images.githubusercontent.com/56546832/170964658-7d63b1a1-3535-4081-bb85-9e9654852457.png)
