### PR TITLE
#171 - routify for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev:cypress": "routify -c dev:vite",
     "dev:vite": "vite",
     "dev:vite:host": "vite --host",
-    "build": "vite build",
+    "build": "routify -c build:vite",
+    "build:vite": "vite build",
     "preview": "vite preview",
     "test": "mocha --require @babel/register",
     "lint": "eslint src test"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "dev:cypress": "routify -c dev:vite",
     "dev:vite": "vite",
     "dev:vite:host": "vite --host",
-    "build": "routify -c build:vite",
-    "build:vite": "vite build",
+    "build": "routify -b && vite build",
     "preview": "vite preview",
     "test": "mocha --require @babel/register",
     "lint": "eslint src test"


### PR DESCRIPTION
Looks like we had missing Routify build for building process in deploy. I hope this is the last PR about Vite migration.

Should close #171.