### PR TITLE
#278 - fix slug in activities table

### DIFF
--- a/app/Filament/Resources/ActivityResource.php
+++ b/app/Filament/Resources/ActivityResource.php
@@ -52,6 +52,7 @@ class ActivityResource extends Resource
                         Forms\Components\TextInput::make("slug")
                             ->label("Slug")
                             ->required()
+                            ->unique(ignoreRecord: true)
                             ->alphaDash()
                             ->maxLength(255),
                         Forms\Components\Checkbox::make("published")

--- a/database/migrations/2024_06_28_074839_change_slug_in_activities_table.php
+++ b/database/migrations/2024_06_28_074839_change_slug_in_activities_table.php
@@ -17,7 +17,7 @@ return new class() extends Migration {
     public function down(): void
     {
         Schema::table("activities", function (Blueprint $table): void {
-            $table->dropUnique("slug");
+            $table->dropUnique(["slug"]);
         });
     }
 };

--- a/database/migrations/2024_06_28_074839_change_slug_in_activities_table.php
+++ b/database/migrations/2024_06_28_074839_change_slug_in_activities_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->unique('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropUnique('slug');
+        });
+    }
+};

--- a/database/migrations/2024_06_28_074839_change_slug_in_activities_table.php
+++ b/database/migrations/2024_06_28_074839_change_slug_in_activities_table.php
@@ -1,22 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class() extends Migration {
     public function up(): void
     {
-        Schema::table('activities', function (Blueprint $table) {
-            $table->unique('slug');
+        Schema::table("activities", function (Blueprint $table): void {
+            $table->unique("slug");
         });
     }
 
     public function down(): void
     {
-        Schema::table('activities', function (Blueprint $table) {
-            $table->dropUnique('slug');
+        Schema::table("activities", function (Blueprint $table): void {
+            $table->dropUnique("slug");
         });
     }
 };

--- a/database/migrations/2024_06_28_081839_change_slug_in_case_studies_table.php
+++ b/database/migrations/2024_06_28_081839_change_slug_in_case_studies_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table("case_studies", function (Blueprint $table): void {
+            $table->unique("slug");
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table("case_studies", function (Blueprint $table): void {
+            $table->dropUnique(["slug"]);
+        });
+    }
+};


### PR DESCRIPTION
User can no longer create two activities with the same slug - fixed with migration and with activity resource rule.
Also added unique() to slug column in case study.
It should close #278.