### PR TITLE
- fix composer plugins

### DIFF
--- a/environment/prod/app/Dockerfile
+++ b/environment/prod/app/Dockerfile
@@ -8,7 +8,6 @@ COPY composer.json composer.lock ./
 
 RUN composer install \
         --no-interaction \
-        --no-plugins \
         --no-scripts \
         --no-dev \
         --prefer-dist \

--- a/environment/prod/app/Dockerfile
+++ b/environment/prod/app/Dockerfile
@@ -94,7 +94,11 @@ RUN rm --recursive --force \
     vite.config.js \
     .dockerignore
 
+USER www-data
+
 RUN composer dump-autoload --optimize
+
+USER root
 
 EXPOSE 80
 


### PR DESCRIPTION
This PR fixes composer install command during deployment. 
Plugins were ignored, but `laravel-localized-routes` package use plugin to autoload helpers.php file.
https://github.com/codezero-be/laravel-localized-routes/blob/master/composer.json#L65-L67

Sum up:
- composer install in the final stage is not running under root user
- plugins are enabled during composer install commands

---
related issues:
- #287 

Closes #287 