### PR TITLE
- fix to showing html tag to news

### DIFF
--- a/resources/views/single-news.blade.php
+++ b/resources/views/single-news.blade.php
@@ -117,7 +117,7 @@
                                 </a>
                             </h3>
                             <div class="line-clamp-2 text-sm text-gray-400">
-                                {{ $recommendedSingleNews['description'] }}
+                                {!! $recommendedSingleNews['description'] !!}
                             </div>
                         </div>
                     @endforeach


### PR DESCRIPTION
In this pr I fixed showing html tags in recommended news. Thanks @vojcc for reporting this