### PR TITLE
- fix missing Accept-Language header

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
         /** @var Request $request */
         $request = app("request");
 
-        if ($request->getRequestUri() === "/" && str_starts_with($request->header("Accept-Language"), "pl")) {
+        if ($request->getRequestUri() === "/" && str_starts_with($request->header("Accept-Language", default: ""), "pl")) {
             $request->setLocale("pl");
             app()->setLocale("pl");
         }


### PR DESCRIPTION
This PR fixes missing `Accept-Language` header.
By default `$request->header()` returns `null` but `str_starts_with()` require `string` type.

Sentry issue:
- https://blumilk.sentry.io/issues/5994456914/?project=4508086290612224&referrer=project-issue-stream
```
TypeError
str_starts_with(): Argument #1 ($haystack) must be of type string, null given
```