### PR TITLE
- fix UTF-8 encoding issue in tag query

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -15,7 +15,11 @@ class NewsController extends Controller
 {
     public function index(Request $request, Factory $factory): View
     {
-        $tagFromQuery = mb_convert_encoding($request->input("tag"), "UTF-8", "auto");
+        $tagFromQuery = $request->input("tag");
+
+        if ($tagFromQuery) {
+            $tagFromQuery = mb_convert_encoding($tagFromQuery, 'UTF-8', 'auto');
+        }
 
         $tag = $tagFromQuery
             ? Tag::query()

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -15,7 +15,7 @@ class NewsController extends Controller
 {
     public function index(Request $request, Factory $factory): View
     {
-        $tagFromQuery = $request->input("tag");
+        $tagFromQuery = $request->get("tag");
 
         if ($tagFromQuery) {
             $tagFromQuery = mb_convert_encoding($tagFromQuery, "UTF-8", "auto");

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -15,7 +15,7 @@ class NewsController extends Controller
 {
     public function index(Request $request, Factory $factory): View
     {
-        $tagFromQuery = mb_convert_encoding($request->input("tag"), 'UTF-8', 'auto');
+        $tagFromQuery = mb_convert_encoding($request->input("tag"), "UTF-8", "auto");
 
         $tag = $tagFromQuery
             ? Tag::query()

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -15,7 +15,8 @@ class NewsController extends Controller
 {
     public function index(Request $request, Factory $factory): View
     {
-        $tagFromQuery = $request->get("tag");
+        $tagFromQuery = mb_convert_encoding($request->input("tag"), 'UTF-8', 'auto');
+
         $tag = $tagFromQuery
             ? Tag::query()
                 ->where("title->pl", "LIKE", $tagFromQuery)

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -18,7 +18,7 @@ class NewsController extends Controller
         $tagFromQuery = $request->input("tag");
 
         if ($tagFromQuery) {
-            $tagFromQuery = mb_convert_encoding($tagFromQuery, 'UTF-8', 'auto');
+            $tagFromQuery = mb_convert_encoding($tagFromQuery, "UTF-8", "auto");
         }
 
         $tag = $tagFromQuery


### PR DESCRIPTION
This PR fixes `QueryException` errors caused by invalid UTF-8 byte sequences in tag search queries. It ensures that only valid UTF-8 strings are processed, preventing invalid byte sequences from causing database errors.