### PR TITLE
- add English email template from contact form

### DIFF
--- a/app/DTOs/ContactFormResponse.php
+++ b/app/DTOs/ContactFormResponse.php
@@ -12,6 +12,7 @@ class ContactFormResponse
         public string $subject,
         public string $response,
         public string $messageDescription,
+        public string $locale,
     ) {}
 
     public static function fromArray(ContactForm $record, array $data): self
@@ -20,6 +21,7 @@ class ContactFormResponse
             subject: $data["responseTopic"],
             response: $data["response"],
             messageDescription: $record->message,
+            locale: $record->lang,
         );
     }
 }

--- a/app/Filament/Resources/ContactFormResource/Actions/RespondToContactFormMessageAction.php
+++ b/app/Filament/Resources/ContactFormResource/Actions/RespondToContactFormMessageAction.php
@@ -48,6 +48,8 @@ class RespondToContactFormMessageAction extends Action
                     ->required(),
             ])
             ->action(function (ContactForm $record, array $data): void {
+                app()->setLocale($record->lang);
+
                 $details = ContactFormResponse::fromArray($record, $data);
 
                 Mail::to($record->email)->send(new ContactFormResponded($details));

--- a/app/Http/Requests/StoreRequest.php
+++ b/app/Http/Requests/StoreRequest.php
@@ -26,6 +26,7 @@ class StoreRequest extends FormRequest
             "email" => $this->get("email"),
             "topic" => $this->get("topic"),
             "message" => $this->get("message"),
+            "lang" => app()->getLocale(),
         ];
     }
 }

--- a/app/Mail/ContactFormResponded.php
+++ b/app/Mail/ContactFormResponded.php
@@ -21,6 +21,7 @@ class ContactFormResponded extends Mailable
     public function build(): self
     {
         return $this->subject($this->details->subject)
-            ->view("email");
+            ->view("email")
+            ->with(["details" => $this->details]);
     }
 }

--- a/app/Models/ContactForm.php
+++ b/app/Models/ContactForm.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $email
  * @property string $topic
  * @property string $message
+ * @property string $lang
  * @property ContactFormStatus $status
  */
 class ContactForm extends Model
@@ -24,6 +25,7 @@ class ContactForm extends Model
         "message",
         "status",
         "response",
+        "lang",
     ];
     protected $casts = [
         "status" => ContactFormStatus::class,

--- a/database/migrations/2024_10_16_083511_add_lang_column_in_contact_forms_table.php
+++ b/database/migrations/2024_10_16_083511_add_lang_column_in_contact_forms_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table("contact_forms", function (Blueprint $table): void {
+            $table->string("lang")->default("pl");
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table("contact_forms", function (Blueprint $table): void {
+            $table->dropColumn("lang");
+        });
+    }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
         - website-dev
         - traefik-proxy-blumilk-local
       ports:
-        - ${DOCKER_MAILPIT_DASHBOARD_HOST_PORT:-63854}:8025
+        - ${DOCKER_MAILPIT_DASHBOARD_HOST_PORT:-34622}:8025
       restart: unless-stopped
 
     redis:

--- a/lang/en/email.php
+++ b/lang/en/email.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    "subject" => "Response to contact form",
+    "header" => "Response from contact form",
+    "your_message" => "Your message",
+    "response" => "Response",
+];

--- a/lang/pl/email.php
+++ b/lang/pl/email.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    "subject" => "Odpowiedź na formularz kontaktowy",
+    "header" => "Odpowiedź z formularza kontaktowego",
+    "your_message" => "Twoja wiadomość",
+    "response" => "Odpowiedź",
+];

--- a/resources/views/email.blade.php
+++ b/resources/views/email.blade.php
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="pl">
+<html lang="{{ app()->getLocale() }}">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Odpowiedź na formularz kontaktowy</title>
+    <title>{{ __('email.subject') }}</title>
     <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600&display=swap" rel="stylesheet">
     <style>
         body {
@@ -157,17 +157,17 @@
     <tr>
         <td class="container">
             <div class="content">
-                <h1>Odpowiedź z formularza kontaktowego</h1>
+                <h1>{{ __('email.header') }}</h1>
                 <table role="presentation" style="width: 100%;" class="main">
                     <tr>
                         <td class="wrapper">
                             <div class="message">
-                                <h3>Twoja wiadomość</h3>
+                                <h3>{{ __('email.your_message') }}</h3>
                                 <div class="message-box">
                                     <p>{!! $details->messageDescription !!}</p>
                                 </div>
                             </div>
-                            <h3>Odpowiedź</h3>
+                            <h3>{{ __('email.response') }}</h3>
                             <div class="response-box">
                                 {!! $details->response !!}
                             </div>


### PR DESCRIPTION
The changes made improve the user experience by allowing users to receive responses in their preferred language (more specifically, the language the site was in when they sent a message via the contact form). 