### PR TITLE
#399 - fix encoding in contact form

### DIFF
--- a/app/Http/Requests/StoreRequest.php
+++ b/app/Http/Requests/StoreRequest.php
@@ -23,9 +23,9 @@ class StoreRequest extends FormRequest
     public function getData(): array
     {
         return [
-            "email" => $this->get("email"),
-            "topic" => $this->get("topic"),
-            "message" => $this->get("message"),
+            "email" => mb_convert_encoding($this->get("email"), "UTF-8", "auto"),
+            "topic" => mb_convert_encoding($this->get("topic"), "UTF-8", "auto"),
+            "message" => mb_convert_encoding($this->get("message"), "UTF-8", "auto"),
             "lang" => app()->getLocale(),
         ];
     }


### PR DESCRIPTION
This PR fixes `PDOException` errors caused by invalid UTF-8 byte sequences in contact form. It ensures that only valid UTF-8 strings are processed, preventing invalid byte sequences from causing database errors.

This should close #399.