### PR TITLE
- fix date in footer

### DIFF
--- a/resources/views/email.blade.php
+++ b/resources/views/email.blade.php
@@ -185,7 +185,7 @@
                         </div>
                     </div>
                     <div class="footer-bottom">
-                        <div class="footer-copy">Copyright &copy; 2024 | Blumilk</div>
+                        <div class="footer-copy">Copyright &copy; {{ date('Y') }} | Blumilk</div>
                         <div>
                             <a href="{{ route('privacy-policy') }}" target="_blank">{{ __('footer.policy') }}</a> |
                             <a href="{{ route('data') }}">{{ __('footer.data') }}</a>

--- a/resources/views/layout/footer.blade.php
+++ b/resources/views/layout/footer.blade.php
@@ -29,7 +29,7 @@
     <div class="px-16 w-full py-6 md:py-6 md:flex md:items-center md:justify-between bg-gray-extraLight text-[#6B6E70]">
         <div>
             <p class="text-center text-sm leading-5">
-                <span class="pr-1">Copyright &copy; 2024</span>
+                <span class="pr-1">Copyright &copy; {{ date('Y') }}</span>
                 <span class="hidden md:inline">|</span>
                 <span class="pl-1">Blumilk <span class="hidden md:inline">sp. z o.o.</span></span>
             </p>


### PR DESCRIPTION
In this pull request I fixed static date in footers (website, mail):
![image](https://github.com/user-attachments/assets/4cb197d0-f6db-48f0-b5a4-7cb38add435a)

Now the date in the footer is updated automatically.