### PR TITLE
- fix invalid URL error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@typescript-eslint/parser": "^8.17.0",
                 "autoprefixer": "^10.4.20",
                 "postcss": "^8.4.49",
-                "vite": "^6.0.3"
+                "vite": "^6.0.11"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -4088,9 +4088,9 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "6.0.9",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.9.tgz",
-            "integrity": "sha512-MSgUxHcaXLtnBPktkbUSoQUANApKYuxZ6DrbVENlIorbhL2dZydTLaZ01tjUoE3szeFzlFk9ANOKk0xurh4MKA==",
+            "version": "6.0.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+            "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.24.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
         "@types/alpinejs__focus": "^3.13.4",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
-        "vite": "^6.0.3"
+        "vite": "^6.0.11"
     }
 }


### PR DESCRIPTION
After fresh clone and setup project, after running command `make run` I had error 

```
error when starting dev server:
TypeError: Invalid URL
    at new URL (node:internal/url:816:29)
    at getAdditionalAllowedHosts (file:///application/node_modules/vite/dist/node/chunks/dep-CjorC8P2.js:59194:29)
    at resolveConfig (file:///application/node_modules/vite/dist/node/chunks/dep-CjorC8P2.js:66549:29)
    at async _createServer (file:///application/node_modules/vite/dist/node/chunks/dep-CjorC8P2.js:62901:18)
    at async CAC.<anonymous> (file:///application/node_modules/vite/dist/node/cli.js:736:20)
```

I read on the Internet that problem is with vite version - so I upgrade it and now it works like a charm