### PR TITLE
#20 - add umami analytics

### DIFF
--- a/resources/views/career.blade.php
+++ b/resources/views/career.blade.php
@@ -135,7 +135,9 @@
                     <h2 class="font-semibold text-gray-900 leading-7.5 text-md md:text-4xl lg:text-5xl mb-4 md:mb-10">{{ __("content.career.section_3.title_1") }}</h2>
                     <p class="text-xs md:text-lg font-normal text-center xl:text-start text-gray-400 leading-7.5 mx-8 md:mx-0">{{ __("content.career.section_3.subtitle_1") }}</p>
                 </div>
-                <x-primary-button href="https://praktyki.blumilk.pl/" target="_blank" class="px-16 my-6 flex w-full md:w-auto m-auto xl:m-0 xl:mr-auto xl:justify-start bg-website-normal">{{ __("buttons.apply_internship") }}</x-primary-button>
+                <x-primary-button href="https://praktyki.blumilk.pl/" target="_blank"
+                                  data-umami-event="outbound-link-click" data-umami-event-url="https://praktyki.blumilk.pl/"
+                                  class="px-16 my-6 flex w-full md:w-auto m-auto xl:m-0 xl:mr-auto xl:justify-start bg-website-normal">{{ __("buttons.apply_internship") }}</x-primary-button>
             </div>
             <div class="flex relative self-center basis-3/5">
                 <img src="{{ asset('graphics/career_2.svg') }}" class="h-auto w-full object-center shrink-0 pt-4 pb-10 md:pb-0"

--- a/resources/views/career.blade.php
+++ b/resources/views/career.blade.php
@@ -136,7 +136,7 @@
                     <p class="text-xs md:text-lg font-normal text-center xl:text-start text-gray-400 leading-7.5 mx-8 md:mx-0">{{ __("content.career.section_3.subtitle_1") }}</p>
                 </div>
                 <x-primary-button href="https://praktyki.blumilk.pl/" target="_blank"
-                                  data-umami-event="outbound-link-click" data-umami-event-url="https://praktyki.blumilk.pl/"
+                                  data-umami-event="praktyki-link-click" data-umami-event-url="https://praktyki.blumilk.pl/"
                                   class="px-16 my-6 flex w-full md:w-auto m-auto xl:m-0 xl:mr-auto xl:justify-start bg-website-normal">{{ __("buttons.apply_internship") }}</x-primary-button>
             </div>
             <div class="flex relative self-center basis-3/5">

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -73,7 +73,8 @@
                 </div>
                 <div class="mt-3 flex">
                     <button type="submit"
-                            class="w-full text-xl mx-0 bg-website-normal m-2 p-3 sm:text-lg h-min text-center font-normal text-white shadow-sm rounded-xl transform transition hover:scale-110 flex justify-center items-center">
+                            class="w-full text-xl mx-0 bg-website-normal m-2 p-3 sm:text-lg h-min text-center font-normal text-white shadow-sm rounded-xl transform transition hover:scale-110 flex justify-center items-center"
+                            data-umami-event="send-contact-form-button-click">
                         {{ __('buttons.send_message') }}
                     </button>
                 </div>

--- a/resources/views/layout/footer.blade.php
+++ b/resources/views/layout/footer.blade.php
@@ -4,23 +4,23 @@
             <img class="w-24 md:w-32 shrink-0 mx-auto" src="{{ asset('identification/logo.svg') }}" alt="Blumilk logo"/>
         </div>
         <div class="flex justify-center items-center space-x-4 md:space-x-6">
-            <a href="https://clutch.co/profile/blumilk-0" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank">
+            <a href="https://clutch.co/profile/blumilk-0" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://clutch.co/profile/blumilk-0">
                 <span class="sr-only">{{ __('alt.clutch') }}</span>
                 <x-icons.clutch></x-icons.clutch>
             </a>
-            <a href="https://github.com/blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank">
+            <a href="https://github.com/blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://github.com/blumilksoftware">
                 <span class="sr-only">{{ __('alt.github') }}</span>
                 <i class="fa-brands fa-square-github text-xl lg:text-2xl"></i>
             </a>
-            <a href="https://linkedin.com/company/blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank">
+            <a href="https://linkedin.com/company/blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://linkedin.com/company/blumilksoftware">
                 <span class="sr-only">{{ __('alt.linkedin') }}</span>
                 <i class="fa-brands fa-linkedin text-xl lg:text-2xl"></i>
             </a>
-            <a href="https://www.facebook.com/blumilksoftware/" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank">
+            <a href="https://www.facebook.com/blumilksoftware/" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://www.facebook.com/blumilksoftware/">
                 <span class="sr-only">{{ __('alt.facebook') }}</span>
                 <i class="fa-brands fa-square-facebook text-xl lg:text-2xl"></i>
             </a>
-            <a href="https://www.youtube.com/@blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank">
+            <a href="https://www.youtube.com/@blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://www.youtube.com/@blumilksoftware">
                 <span class="sr-only">{{ __('alt.youtube') }}</span>
                 <i class="fa-brands fa-square-youtube text-xl lg:text-2xl"></i>
             </a>
@@ -36,7 +36,7 @@
         </div>
         <div class="mt-2 md:mt-0">
             <p class="text-center text-sm leading-5">
-                <a href="https://github.com/blumilksoftware/website" target="_blank" class="block md:inline font-normal whitespace-normal pr-1">{{ __('footer.code') }}</a>
+                <a href="https://github.com/blumilksoftware/website" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://github.com/blumilksoftware/website" class="block md:inline font-normal whitespace-normal pr-1">{{ __('footer.code') }}</a>
                 <span class="hidden md:inline">|</span>
                 <a href="{{ route('privacy-policy') }}" class="block md:inline font-normal whitespace-normal px-1">{{ __('footer.policy') }}</a>
                 <span class="hidden md:inline">|</span>

--- a/resources/views/layout/footer.blade.php
+++ b/resources/views/layout/footer.blade.php
@@ -4,23 +4,23 @@
             <img class="w-24 md:w-32 shrink-0 mx-auto" src="{{ asset('identification/logo.svg') }}" alt="Blumilk logo"/>
         </div>
         <div class="flex justify-center items-center space-x-4 md:space-x-6">
-            <a href="https://clutch.co/profile/blumilk-0" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://clutch.co/profile/blumilk-0">
+            <a href="https://clutch.co/profile/blumilk-0" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="clutch-profile-link-click" data-umami-event-url="https://clutch.co/profile/blumilk-0">
                 <span class="sr-only">{{ __('alt.clutch') }}</span>
                 <x-icons.clutch></x-icons.clutch>
             </a>
-            <a href="https://github.com/blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://github.com/blumilksoftware">
+            <a href="https://github.com/blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="github-profile-link-click" data-umami-event-url="https://github.com/blumilksoftware">
                 <span class="sr-only">{{ __('alt.github') }}</span>
                 <i class="fa-brands fa-square-github text-xl lg:text-2xl"></i>
             </a>
-            <a href="https://linkedin.com/company/blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://linkedin.com/company/blumilksoftware">
+            <a href="https://linkedin.com/company/blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="linkedin-profile-link-click" data-umami-event-url="https://linkedin.com/company/blumilksoftware">
                 <span class="sr-only">{{ __('alt.linkedin') }}</span>
                 <i class="fa-brands fa-linkedin text-xl lg:text-2xl"></i>
             </a>
-            <a href="https://www.facebook.com/blumilksoftware/" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://www.facebook.com/blumilksoftware/">
+            <a href="https://www.facebook.com/blumilksoftware/" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="facebook-profile-link-click" data-umami-event-url="https://www.facebook.com/blumilksoftware/">
                 <span class="sr-only">{{ __('alt.facebook') }}</span>
                 <i class="fa-brands fa-square-facebook text-xl lg:text-2xl"></i>
             </a>
-            <a href="https://www.youtube.com/@blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://www.youtube.com/@blumilksoftware">
+            <a href="https://www.youtube.com/@blumilksoftware" class="text-gray-400 hover:text-gray-500 leading-none" target="_blank" data-umami-event="youtube-profile-link-click" data-umami-event-url="https://www.youtube.com/@blumilksoftware">
                 <span class="sr-only">{{ __('alt.youtube') }}</span>
                 <i class="fa-brands fa-square-youtube text-xl lg:text-2xl"></i>
             </a>
@@ -36,7 +36,7 @@
         </div>
         <div class="mt-2 md:mt-0">
             <p class="text-center text-sm leading-5">
-                <a href="https://github.com/blumilksoftware/website" target="_blank" data-umami-event="outbound-link-click" data-umami-event-url="https://github.com/blumilksoftware/website" class="block md:inline font-normal whitespace-normal pr-1">{{ __('footer.code') }}</a>
+                <a href="https://github.com/blumilksoftware/website" target="_blank" data-umami-event="github-source-code-link-click" data-umami-event-url="https://github.com/blumilksoftware/website" class="block md:inline font-normal whitespace-normal pr-1">{{ __('footer.code') }}</a>
                 <span class="hidden md:inline">|</span>
                 <a href="{{ route('privacy-policy') }}" class="block md:inline font-normal whitespace-normal px-1">{{ __('footer.policy') }}</a>
                 <span class="hidden md:inline">|</span>

--- a/resources/views/layout/public.blade.php
+++ b/resources/views/layout/public.blade.php
@@ -26,8 +26,8 @@
     <link href='https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.css' rel='stylesheet'/>
     <script
         defer src="https://analytics.blumilk.pl/script.js"
-        data-website-id="f07919bb-dcef-4970-9efb-e732177147ab"
-        data-domains="dev.website.blumilk.pl">
+        data-website-id="a60fb021-70a4-4829-9209-a690f6fcb79f"
+        data-domains="blumilk.pl">
     </script>
 </head>
 

--- a/resources/views/layout/public.blade.php
+++ b/resources/views/layout/public.blade.php
@@ -24,6 +24,11 @@
 
     <script src='https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.js'></script>
     <link href='https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.css' rel='stylesheet'/>
+    <script
+        defer src="https://analytics.blumilk.pl/script.js"
+        data-website-id="f07919bb-dcef-4970-9efb-e732177147ab"
+        data-domains="dev.website.blumilk.pl">
+    </script>
 </head>
 
 <body class="font-sora flex flex-col h-screen justify-between">


### PR DESCRIPTION
This pull request includes updates to the `career` and `footer` views to add tracking for outbound link clicks and the inclusion of an analytics script in the public layout. The most important changes are listed below:

### Addition of tracking attributes:

* [`resources/views/career.blade.php`](diffhunk://#diff-8829ca586302baad6ee5ec998e3169b245f9dd05823a6df78c39f25f0eb9361aL138-R140): Added `data-umami-event` and `data-umami-event-url` attributes to the "Apply Internship" button to track outbound link clicks.
* [`resources/views/layout/footer.blade.php`](diffhunk://#diff-178cb44ccf72f6f34cccea8a692d4160cfb745d3495f88fccc59a590b139ae32L7-R23): Added `data-umami-event` and `data-umami-event-url` attributes to all outbound links in the footer to track clicks. [[1]](diffhunk://#diff-178cb44ccf72f6f34cccea8a692d4160cfb745d3495f88fccc59a590b139ae32L7-R23) [[2]](diffhunk://#diff-178cb44ccf72f6f34cccea8a692d4160cfb745d3495f88fccc59a590b139ae32L39-R39)

### Inclusion of analytics script:

* [`resources/views/layout/public.blade.php`](diffhunk://#diff-cd6212337a4a9bd85c30efc7cd26f33dafb9081a8c87acd592f73b0cff74d2f9R27-R31): Added a deferred script tag for the Umami analytics script to track website analytics.

---

Umami docs:
- [Excluding own visits](https://umami.is/docs/exclude-my-own-visits)
- [Track events](https://umami.is/docs/track-events)
- [Tracker functions](https://umami.is/docs/tracker-functions)
- [Tracker configuration](https://umami.is/docs/tracker-configuration)
- [Tracking outbound links](https://umami.is/docs/track-outbound-links)