### PR TITLE
- make custom validator for recaptcha

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,7 +21,7 @@ class AppServiceProvider extends ServiceProvider
             app()->setLocale("pl");
         }
 
-        $this->app["validator"]->extend("recaptchav3", function ($attribute, $value, $parameters) {
+        $this->app["validator"]->extend("recaptchav3", function ($attribute, $value, $parameters): bool {
             $action = $parameters[0];
             $minScore = isset($parameters[1]) ? (float)$parameters[1] : 0.5;
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Blumilk\Website\Providers;
 
+use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
+use Lunaweb\RecaptchaV3\Facades\RecaptchaV3;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -18,5 +20,18 @@ class AppServiceProvider extends ServiceProvider
             $request->setLocale("pl");
             app()->setLocale("pl");
         }
+
+        $this->app["validator"]->extend("recaptchav3", function ($attribute, $value, $parameters) {
+            $action = $parameters[0];
+            $minScore = isset($parameters[1]) ? (float)$parameters[1] : 0.5;
+
+            try {
+                $score = RecaptchaV3::verify($value, $action);
+
+                return $score && $score >= $minScore;
+            } catch (Exception) {
+                return false;
+            }
+        });
     }
 }

--- a/tests/Unit/RecaptchaTest.php
+++ b/tests/Unit/RecaptchaTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Validator;
+use Lunaweb\RecaptchaV3\Facades\RecaptchaV3;
+use Tests\TestCase;
+
+class RecaptchaTest extends TestCase
+{
+    public function testRecaptchav3ValidationPassesWhenScoreIsHighEnough(): void
+    {
+        RecaptchaV3::shouldReceive("verify")
+            ->once()
+            ->andReturn(0.8);
+
+        $data = ["token" => "dummy-token"];
+        $rules = ["token" => "recaptchav3:contact,0.5"];
+
+        $validator = Validator::make($data, $rules);
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testRecaptchav3ValidationFailsWhenScoreIsTooLow(): void
+    {
+        RecaptchaV3::shouldReceive("verify")
+            ->once()
+            ->andReturn(0.3);
+
+        $data = ["token" => "dummy-token"];
+        $rules = ["token" => "recaptchav3:contact,0.5"];
+
+        $validator = Validator::make($data, $rules);
+
+        $this->assertFalse($validator->passes());
+    }
+
+    public function testRecaptchav3ValidationFailsWhenExceptionIsThrown(): void
+    {
+        RecaptchaV3::shouldReceive("verify")
+            ->once()
+            ->andThrow(new Exception());
+
+        $data = ["token" => "dummy-token"];
+        $rules = ["token" => "recaptchav3:contact,0.5"];
+
+        $validator = Validator::make($data, $rules);
+
+        $this->assertFalse($validator->passes());
+    }
+}


### PR DESCRIPTION
On Monday, an error occurred in production:

Server error: POST https://www.google.com/recaptcha/api/siteverify resulted in a 502 Bad Gateway response: ...

To improve error handling, this PR introduces a custom validator for reCAPTCHA.